### PR TITLE
Find_and_Avoid - fix coordinate system

### DIFF
--- a/examples/find_and_avoid/controllers/supervisor/utilities.py
+++ b/examples/find_and_avoid/controllers/supervisor/utilities.py
@@ -17,8 +17,8 @@ def get_distance_from_target(robot_node, target_node):
     targetCoordinate = target_node.getField('translation').getSFVec3f()
 
     dx = robotCoordinates[0] - targetCoordinate[0]
-    dz = robotCoordinates[2] - targetCoordinate[2]
-    distanceFromTarget = math.sqrt(dx * dx + dz * dz)
+    dy = robotCoordinates[1] - targetCoordinate[1]
+    distanceFromTarget = math.sqrt(dx * dx + dy * dy)
     return distanceFromTarget
 
 
@@ -33,24 +33,24 @@ def get_angle_from_target(robot_node,
     targetCoordinate = target_node.getField('translation').getSFVec3f()
 
     x_r = (targetCoordinate[0] - robotCoordinates[0])
-    z_r = (targetCoordinate[2] - robotCoordinates[2])
+    y_r = (targetCoordinate[1] - robotCoordinates[1])
 
-    z_r = -z_r
+    y_r = -y_r
 
-    # robotWorldAngle = math.atan2(robotCoordinates[2], robotCoordinates[0])
+    # robotWorldAngle = math.atan2(robotCoordinates[1], robotCoordinates[0])
 
     if robotAngle < 0.0: robotAngle += 2 * np.pi
 
     x_f = x_r * math.sin(robotAngle) - \
-          z_r * math.cos(robotAngle)
+          y_r * math.cos(robotAngle)
 
-    z_f = x_r * math.cos(robotAngle) + \
-          z_r * math.sin(robotAngle)
+    y_f = x_r * math.cos(robotAngle) + \
+          y_r * math.sin(robotAngle)
 
-    # print("x_f: {} , z_f: {}".format(x_f, z_f) )
+    # print("x_f: {} , y_f: {}".format(x_f, y_f) )
     if is_true_angle:
         x_f = -x_f
-    angleDif = math.atan2(z_f, x_f)
+    angleDif = math.atan2(y_f, x_f)
 
     if is_abs:
         angleDif = abs(angleDif)

--- a/examples/find_and_avoid/worlds/small_world.wbt
+++ b/examples/find_and_avoid/worlds/small_world.wbt
@@ -1,13 +1,13 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022a utf8
 WorldInfo {
-  coordinateSystem "NUE"
 }
 Viewpoint {
-  orientation -0.999993584557609 0.0025653260563713327 0.002499989169686478 1.545006413329063
-  position -0.0696317107449893 2.632085990439978 0.07609127999188595
+  orientation 0.002499992187536621 0.9999968750146484 0 1.54
+  position -0.0769789523060592 -0.009762317935755683 1.9019529461174487
 }
 WoodenBox {
-  translation -0.12 0.08 0.1
+  translation -0.1 0.16 0.07
+  rotation 0.5773509358554485 0.5773489358556708 0.5773509358554485 2.0944
   size 0.06 0.15 0.5
 }
 TexturedBackground {
@@ -20,8 +20,10 @@ RectangleArena {
 DEF supervisor Robot {
   children [
     DEF emitter Emitter {
+      rotation -0.5773502691896258 -0.5773502691896258 -0.5773502691896258 2.0943951023931953
     }
     DEF receiver Receiver {
+      rotation -0.5773502691896258 -0.5773502691896258 -0.5773502691896258 2.0943951023931953
     }
   ]
   name "supervisor"
@@ -29,14 +31,15 @@ DEF supervisor Robot {
   supervisor TRUE
 }
 DEF robot E-puck {
-  translation -0.247908 0.000104606 0.267582
+  translation -0.26 0.27 0
   name "robot"
   controller "robot"
   emitter_channel 0
   receiver_channel 0
 }
 DEF target Solid {
-  translation 0.26 0.01 -0.25
+  translation 0.26 -0.23 0.01
+  rotation 0 0 1 -1.5707953071795862
   children [
     Shape {
       appearance Appearance {


### PR DESCRIPTION
I switch Find_and_Avoid Goal example to ENU that is the new default coordinate system on Webots R2022a.