### PR TITLE
Fixed get_angle_from_target and ImageTexture url

### DIFF
--- a/examples/find_and_avoid/controllers/supervisor/supervisor.py
+++ b/examples/find_and_avoid/controllers/supervisor/supervisor.py
@@ -66,10 +66,7 @@ class FindTargetSupervisor(SupervisorCSV):
                 distance_from_target, EUCL_MM['min'], EUCL_MM['max'], 0, 1)
             observation.append(distance_from_target)
 
-            angle_from_target = utils.get_angle_from_target(self.robot,
-                                                          self.target,
-                                                          is_true_angle=True,
-                                                          is_abs=False)
+            angle_from_target = utils.get_angle_from_target(self.robot, self.target, is_abs=False)
             self.message.append(angle_from_target)
             angle_from_target = utils.normalize_to_range(angle_from_target,
                                                        ANGLE_MM['min'],

--- a/examples/find_and_avoid/worlds/small_world.wbt
+++ b/examples/find_and_avoid/worlds/small_world.wbt
@@ -54,7 +54,7 @@ DEF target Solid {
         }
         texture ImageTexture {
           url [
-            "https://avatars.githubusercontent.com/u/57842071?s=200&v=4"
+            "https://avatars.githubusercontent.com/u/57842071?s=256"
           ]
         }
       }


### PR DESCRIPTION
1. get_angle_from_target returns a wrong value.
    * We want to get $\alpha - \theta \in (-\pi, \pi]$
    * ref.: https://math.stackexchange.com/a/14180
    <img src="https://user-images.githubusercontent.com/49781698/210778242-afbc2083-6eb1-4441-bba3-a4f50541f755.png" alt="drawing" width="400"/>
2. Fixed the following warning message.
![image](https://user-images.githubusercontent.com/49781698/210778995-125aae91-84fc-4559-84c0-e6a7a1946cd9.png)