### PR TITLE
Fixed PPO ImportError and removed requests==2.28.0

### DIFF
--- a/examples/khr-3hv/khr-3hv_continuous/controllers/robot_supervisor_manager/PPO_runner.py
+++ b/examples/khr-3hv/khr-3hv_continuous/controllers/robot_supervisor_manager/PPO_runner.py
@@ -7,7 +7,10 @@ import wandb
 import ray
 from ray import tune
 from ray.tune.registry import register_env
-import ray.rllib.agents.ppo as ppo
+try:
+    from ray.rllib.agents.ppo import ppo
+except ImportError:
+    from ray.rllib.algorithms.ppo import ppo
 from ray.tune.integration.wandb import WandbLoggerCallback
 
 from KHR3HV_env import KHR3HVRobotSupervisor

--- a/examples/khr-3hv/khr-3hv_continuous/requirements/khr_3hv.txt
+++ b/examples/khr-3hv/khr-3hv_continuous/requirements/khr_3hv.txt
@@ -3,5 +3,4 @@ numpy
 matplotlib
 stable_baselines3
 ray[rllib]
-requests==2.28.0
 wandb


### PR DESCRIPTION
1. The `agents` folder has been deprecated in favor of algorithms on ray 2.x version.
    To be backward compatible, we can use `try ... except ...` to import ppo.
    * https://discuss.ray.io/t/ray-rllib-agents-ppo-missing/9904
    
2. Removed requests==2.28.0
    It seems that `requests` is already listed in the requirements.txt of ray, so I think we can remove it.
    * https://github.com/ray-project/ray/blob/master/release/requirements.txt
    * https://github.com/aidudezzz/deepworlds/pull/94